### PR TITLE
ENH: support frame averaging

### DIFF
--- a/adk.yaml
+++ b/adk.yaml
@@ -15,7 +15,7 @@ mode: "image"
 # depending on `mode`
 render_filename: "test"
 frame_start: 0
-frame_end: 285
+frame_end: 95
 # TODO: expand selection support beyond a single selection string
 sel_string: "all"
 background_color:
@@ -30,9 +30,13 @@ focal_length: 80
 # to continue to capture the same effective trajectory length;
 # so with subframes of 1 you would double upper frame bound,
 # with value of 2 you would triple, etc.
-subframes: 2
+subframes: 0
 # at the moment, interesting materials options include:
 # default -- looks professional
 # ambient -- also looks professional
 # squishy -- a plastic-like appearance, pretty neat!
 material: "default"
+# average can be increased for averaging positions over
+# flanking frames to help avoid i.e., "jittering" in movie renders;
+# in contrast to subframes, no additional frames are added
+average: 3

--- a/probe.py
+++ b/probe.py
@@ -44,6 +44,7 @@ def main(p_config: dict):
     background_color = p_config["background_color"]
     focal_length = p_config["focal_length"]
     subframes = p_config["subframes"]
+    average = p_config["average"]
     material = p_config["material"]
 
     if mode == "movie":
@@ -57,6 +58,7 @@ def main(p_config: dict):
         bpy.context.scene.cycles.device = blender_engine_device
 
     ggmv = GGMolVis()
+    ggmv.average = average
     u = mda.Universe(topology_path, trajectory_path)
     system = u.select_atoms(sel_string)
     all_mol = ggmv.molecule(system, lens=focal_length, material=material)


### PR DESCRIPTION
* Allow the user to specify frame averaging in the YAML input deck. Since no additional frames are added using this approach, I've turned off the usage of subframes by default for now with ADK--instead preferring to average over the flanking 3 frames for faster smooth renders.

* Verified the "smoother" ADK movie render locally with the new averaging feature.

The corresponding support in `ggmolvis` was recently merged in https://github.com/yuxuanzhuang/ggmolvis/pull/22